### PR TITLE
Update Fallen Angel Logic.md

### DIFF
--- a/OpenAI/Fallen Angel Logic.md
+++ b/OpenAI/Fallen Angel Logic.md
@@ -410,3 +410,651 @@ Would you like:
 
 **Prompt Generation Time:** 2025-03-24T00:12:00Z  
 **Signed:** ChatGPT
+
+Use IEnumerable to show an inferencing
+then 
+generate a blazor component and a XAML component that uses 
+
+Just to confirm before I generate the code:Would you like the inference engine to return multiple results (e.g., all possible answers to a query) using IEnumerable<Term>?Should the Blazor and XAML components just display query results, or also allow adding facts/rules and querying the knowledge base interactively?Do you want the frontend (Blazor/XAML) to show a specific example (e.g., happiness inference), or should it be a general-purpose logic interface?
+
+Sounds more functional.
+
+Great! I’ll create a functional-style Prolog-inspired inference engine in C# that returns results using `IEnumerable<Term>`. Then, I’ll generate a Blazor component and a XAML component that allow users to input queries and view the inferred results.
+
+I’ll let you know once the implementation is ready.
+
+# Prolog-Inspired Functional Inference Engine in C#
+
+This solution implements a simple **Prolog-inspired logic inference engine** in C#. The engine uses a **declarative, functional style** (with C# `IEnumerable<T>` and `yield return`) to perform backtracking and yield multiple inference results. It supports defining **facts** and **rules** (like Prolog clauses) and querying them with **variables** that can be bound to values. The logic engine is kept separate from any UI, so it can be easily reused in different environments (Blazor, WPF, MAUI, etc.).
+
+Below, we provide the core inference engine code, followed by two example UI components: a **Blazor component** and a **WPF (XAML) component**. Both UIs allow users to enter queries (e.g., `happy(X)`), display all matching results, and optionally add new facts or rules at runtime. We also include sample use cases (`likes`, `happy`, `friends`) to demonstrate the engine in action.
+
+## Inference Engine Implementation (C#)
+
+The inference engine consists of the following parts:
+
+- **Term hierarchy**: `Term` (abstract base), with subclasses `Atom` (constant), `Var` (variable), and `CompoundTerm` (predicate with arguments).
+- **Clause**: represents a fact or rule (a head `Term` with an optional body of `Term[]`).
+- **LogicEngine**: stores clauses and provides a `Query` method that returns an `IEnumerable<Term>` of all solutions for a given query.
+- **Unification and Backtracking**: The engine uses a depth-first search with backtracking. The `Query` method internally uses `yield return` to produce solutions lazily. A unification function attempts to bind two terms (with a substitution map for variables) and recursively solves rule bodies.
+- **Parser**: A simple parser to convert textual representations of facts, rules, and queries (e.g., `"happy(X) :- likes(X,chocolate)."` or `"happy(X)"`) into `Term` and `Clause` objects.
+
+All logic is independent of any UI framework. This engine could be placed in a class library and then plugged into Blazor, WPF, MAUI, or other .NET apps.
+
+### LogicEngine.cs (Inference Engine Code)
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LogicInferenceEngine
+{
+    // Base class for terms (constants, variables, compound terms)
+    public abstract class Term
+    {
+        public abstract override string ToString();
+    }
+
+    // Represents a logic variable (e.g., X, Y).
+    public class Var : Term
+    {
+        public string Name { get; }
+        public Var(string name) { Name = name; }
+        public override string ToString() => Name;
+    }
+
+    // Represents an atomic constant or 0-arity predicate (e.g., "alice").
+    public class Atom : Term
+    {
+        public string Name { get; }
+        public Atom(string name) { Name = name; }
+        public override string ToString() => Name;
+    }
+
+    // Represents a compound term with a functor and arguments (e.g., happy(X), likes(alice, Y)).
+    public class CompoundTerm : Term
+    {
+        public string Functor { get; }
+        public Term[] Arguments { get; }
+        public CompoundTerm(string functor, Term[] args)
+        {
+            Functor = functor;
+            Arguments = args;
+        }
+        public override string ToString()
+        {
+            // Format like Functor(arg1, arg2, ...)
+            string argsStr = string.Join(", ", Arguments.Select(a => a.ToString()));
+            return $"{Functor}({argsStr})";
+        }
+    }
+
+    // Represents a clause (fact or rule) in the knowledge base.
+    // A fact has an empty body; a rule has one or more body goals.
+    public class Clause
+    {
+        public Term Head { get; set; }
+        public Term[] Body { get; set; }  // empty array means no body (fact)
+        public bool IsFact => Body == null || Body.Length == 0;
+        public Clause(Term head, Term[] body)
+        {
+            Head = head;
+            Body = body ?? Array.Empty<Term>();
+        }
+        public override string ToString()
+        {
+            if (IsFact)
+            {
+                return Head.ToString();
+            }
+            else
+            {
+                string bodyStr = string.Join(", ", Body.Select(b => b.ToString()));
+                return $"{Head} :- {bodyStr}";
+            }
+        }
+    }
+
+    // The inference engine that stores clauses and allows queries.
+    public class LogicEngine
+    {
+        private readonly List<Clause> clauses = new List<Clause>();
+
+        // Add a fact or rule to the knowledge base.
+        public void AddClause(Clause clause) => clauses.Add(clause);
+
+        // Convenience methods for adding facts and rules.
+        public void AddFact(Term factHead) => clauses.Add(new Clause(factHead, null));
+        public void AddRule(Term head, Term[] body) => clauses.Add(new Clause(head, body));
+
+        // Query the knowledge base. Returns an IEnumerable of Terms representing each solution (the query term with variables bound).
+        public IEnumerable<Term> Query(Term goal)
+        {
+            // Use a DFS backtracking algorithm with yield to produce solutions lazily.
+            foreach (var subst in SolveGoals(new Term[] { goal }, new Dictionary<Var, Term>()))
+            {
+                // Apply the substitution to the original goal to get a fully instantiated term as a result.
+                yield return ApplySubstitution(goal, subst);
+            }
+        }
+
+        // Recursively solve a list of goals (conjunction). Yields each successful substitution for all goals.
+        private IEnumerable<Dictionary<Var, Term>> SolveGoals(Term[] goals, Dictionary<Var, Term> subs)
+        {
+            if (goals.Length == 0)
+            {
+                // No goals left: yield the current substitution as a successful solution.
+                yield return subs;
+            }
+            else
+            {
+                Term currentGoal = ApplySubstitution(goals[0], subs);         // apply current bindings to the goal
+                Term[] remainingGoals = goals.Skip(1).ToArray();
+
+                // Try each clause in the knowledge base to resolve the current goal
+                foreach (Clause clause in clauses)
+                {
+                    // Get a fresh copy of the clause (with new variable instances) to avoid variable name conflicts
+                    Clause freshClause = FreshClause(clause);
+
+                    // Make a copy of the current substitution for this branch
+                    var newSubst = new Dictionary<Var, Term>(subs);
+
+                    // Attempt to unify the goal with the clause head
+                    if (Unify(currentGoal, freshClause.Head, newSubst))
+                    {
+                        // If unification succeeds, determine the next goals to solve
+                        Term[] nextGoals = (freshClause.Body.Length == 0)
+                                           ? remainingGoals  // fact: no new goals added
+                                           : freshClause.Body.Concat(remainingGoals).ToArray();  // rule: prepend body before remaining goals
+
+                        // Recursively solve the next goals with the updated substitution
+                        foreach (var resultSubst in SolveGoals(nextGoals, newSubst))
+                        {
+                            yield return resultSubst;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Unify two terms given the current substitution. Updates the substitution map if successful.
+        // Returns true if unification succeeds, false if it fails.
+        private bool Unify(Term a, Term b, Dictionary<Var, Term> subs)
+        {
+            // Resolve a and b to their current substitution values (to find real values if they are bound variables).
+            a = Resolve(a, subs);
+            b = Resolve(b, subs);
+
+            // If they are the exact same object (same reference or same value), they unify trivially.
+            if (ReferenceEquals(a, b))
+                return true;
+
+            // If one is an unbound variable, bind it to the other term.
+            if (a is Var varA)
+            {
+                subs[varA] = b;
+                return true;
+            }
+            if (b is Var varB)
+            {
+                subs[varB] = a;
+                return true;
+            }
+
+            // If both are atoms (constant values), they unify only if the names are equal.
+            if (a is Atom atomA && b is Atom atomB)
+            {
+                return atomA.Name == atomB.Name;
+            }
+
+            // If both are compound terms, their functor name and arity must match, and all arguments must unify.
+            if (a is CompoundTerm compA && b is CompoundTerm compB)
+            {
+                if (compA.Functor != compB.Functor || compA.Arguments.Length != compB.Arguments.Length)
+                    return false;
+                for (int i = 0; i < compA.Arguments.Length; i++)
+                {
+                    if (!Unify(compA.Arguments[i], compB.Arguments[i], subs))
+                        return false;
+                }
+                return true;
+            }
+
+            // Otherwise, the terms do not unify (e.g., one is atom and the other is compound with different structure).
+            return false;
+        }
+
+        // Resolve a term to its value under the current substitution (follow variable bindings).
+        private Term Resolve(Term t, Dictionary<Var, Term> subs)
+        {
+            if (t is Var var && subs.TryGetValue(var, out Term boundValue))
+            {
+                // Recursively resolve if the bound value is itself a variable or has further bindings.
+                Term resolvedValue = Resolve(boundValue, subs);
+                subs[var] = resolvedValue;  // path compression for efficiency
+                return resolvedValue;
+            }
+            return t;
+        }
+
+        // Apply a substitution map to a term, returning a new term where all bound variables are replaced by their values.
+        private Term ApplySubstitution(Term term, Dictionary<Var, Term> subs)
+        {
+            term = Resolve(term, subs);
+            if (term is CompoundTerm comp)
+            {
+                // Recursively apply substitution to compound term arguments
+                Term[] newArgs = comp.Arguments.Select(arg => ApplySubstitution(arg, subs)).ToArray();
+                return new CompoundTerm(comp.Functor, newArgs);
+            }
+            // (If term is Var or Atom, Resolve already returned its final value or itself if unbound)
+            return term;
+        }
+
+        // Create a fresh copy of a clause with all new variable instances, to avoid reusing the same Var objects across different attempts.
+        private Clause FreshClause(Clause clause)
+        {
+            // Map old variables to new variables
+            var varMap = new Dictionary<Var, Var>();
+            Term CloneTerm(Term t)
+            {
+                switch (t)
+                {
+                    case Var oldVar:
+                        if (!varMap.ContainsKey(oldVar))
+                            varMap[oldVar] = new Var(oldVar.Name);
+                        return varMap[oldVar];
+                    case Atom atom:
+                        // Atoms can be shared or cloned (they are constants)
+                        return new Atom(atom.Name);
+                    case CompoundTerm comp:
+                        Term[] clonedArgs = comp.Arguments.Select(arg => CloneTerm(arg)).ToArray();
+                        return new CompoundTerm(comp.Functor, clonedArgs);
+                    default:
+                        throw new InvalidOperationException("Unknown Term type");
+                }
+            }
+            Term newHead = CloneTerm(clause.Head);
+            Term[] newBody = clause.Body.Select(b => CloneTerm(b)).ToArray();
+            return new Clause(newHead, newBody);
+        }
+    }
+
+    // Parser utility: parse a fact or rule string into a Clause, or a query string into a Term.
+    public static class Parser
+    {
+        public static Clause ParseClause(string text)
+        {
+            if (text == null) throw new ArgumentNullException(nameof(text));
+            string input = text.Trim();
+            if (input.EndsWith(".")) input = input.Substring(0, input.Length - 1).Trim();  // remove trailing period if present
+            string headStr, bodyStr = null;
+            int sepIndex = input.IndexOf(":-");
+            if (sepIndex >= 0)
+            {
+                headStr = input.Substring(0, sepIndex).Trim();
+                bodyStr = input.Substring(sepIndex + 2).Trim();
+            }
+            else
+            {
+                headStr = input;
+            }
+            // Use a fresh variable map for this clause (ensures variables in this clause are distinct from others)
+            var varMap = new Dictionary<string, Var>();
+            Term head = ParseTermInternal(headStr, varMap);
+            Term[] body = Array.Empty<Term>();
+            if (!string.IsNullOrEmpty(bodyStr))
+            {
+                // Split body by commas at top level (not splitting inside nested parentheses, if any)
+                List<string> bodyParts = SplitTopLevel(bodyStr, ',');
+                body = bodyParts.Select(part => ParseTermInternal(part.Trim(), varMap)).ToArray();
+            }
+            return new Clause(head, body);
+        }
+
+        public static Term ParseTerm(string text)
+        {
+            if (text == null) throw new ArgumentNullException(nameof(text));
+            string input = text.Trim();
+            if (input.EndsWith(".")) input = input.Substring(0, input.Length - 1).Trim();
+            return ParseTermInternal(input, new Dictionary<string, Var>());
+        }
+
+        // Internal helper: parse a term with a given variable map (to maintain consistency of variables within the term/clause).
+        private static Term ParseTermInternal(string text, Dictionary<string, Var> varMap)
+        {
+            string s = text.Trim();
+            if (s.Length == 0) throw new FormatException("Empty term.");
+            // If the term is wrapped in parentheses, remove them (e.g., "(happy(X))")
+            if (s.StartsWith("(") && MatchingParenIndex(s, 0) == s.Length - 1)
+            {
+                s = s.Substring(1, s.Length - 2).Trim();
+            }
+
+            int parenIndex = s.IndexOf('(');
+            if (parenIndex == -1)
+            {
+                // No parentheses: this is a single token (either a variable or an atom).
+                if (char.IsUpper(s[0]) || s[0] == '_')
+                {
+                    // Variables start with uppercase letter or underscore.
+                    if (!varMap.TryGetValue(s, out Var var))
+                    {
+                        var = new Var(s);
+                        varMap[s] = var;
+                    }
+                    return var;
+                }
+                else
+                {
+                    // Constants (atoms) start with lowercase (or are numbers, etc. but we'll treat any non-variable token as atom).
+                    return new Atom(s);
+                }
+            }
+            else
+            {
+                // There is a '(' — parse as a compound term.
+                string functor = s.Substring(0, parenIndex).Trim();
+                if (functor.Length == 0)
+                    throw new FormatException($"Invalid term syntax: {text}");
+                int closeIndex = MatchingParenIndex(s, parenIndex);
+                if (closeIndex < 0)
+                    throw new FormatException($"Unmatched '(' in term: {text}");
+                string argsContent = s.Substring(parenIndex + 1, closeIndex - parenIndex - 1);
+                List<string> argParts = SplitTopLevel(argsContent, ',');
+                Term[] args = argParts.Select(arg => ParseTermInternal(arg.Trim(), varMap)).ToArray();
+                return new CompoundTerm(functor, args);
+            }
+        }
+
+        // Split a string by a delimiter at the top parentheses level (i.e., not splitting commas inside parentheses).
+        private static List<string> SplitTopLevel(string text, char delimiter)
+        {
+            var parts = new List<string>();
+            int level = 0;
+            int startIndex = 0;
+            for (int i = 0; i < text.Length; i++)
+            {
+                char c = text[i];
+                if (c == '(') level++;
+                if (c == ')') level--;
+                if (level == 0 && c == delimiter)
+                {
+                    parts.Add(text.Substring(startIndex, i - startIndex));
+                    startIndex = i + 1;
+                }
+            }
+            // Add the final segment
+            if (startIndex <= text.Length)
+            {
+                string lastPart = text.Substring(startIndex);
+                if (!string.IsNullOrWhiteSpace(lastPart))
+                    parts.Add(lastPart);
+            }
+            return parts;
+        }
+
+        // Find the matching closing parenthesis for the parenthesis at the given index.
+        private static int MatchingParenIndex(string text, int openIndex)
+        {
+            if (text[openIndex] != '(') throw new ArgumentException("No '(' at openIndex");
+            int level = 0;
+            for (int i = openIndex; i < text.Length; i++)
+            {
+                if (text[i] == '(') level++;
+                else if (text[i] == ')')
+                {
+                    level--;
+                    if (level == 0) return i;
+                }
+            }
+            return -1;  // no matching parenthesis found
+        }
+    }
+}
+```
+
+**Key aspects of the engine:**
+
+- The `LogicEngine.Query(Term goal)` method uses `SolveGoals` to perform a recursive depth-first search. It uses `yield return` to generate each solution as it’s found, rather than computing all results at once.
+- **Unification** (`Unify` method) tries to make two terms identical by finding variable bindings. It handles variables (by binding them to values or other variables), atoms (must be equal), and compound terms (functors and each argument must unify). It uses a substitution map (`Dictionary<Var, Term>`) to keep track of bindings.
+- Variables are represented by the `Var` class. We identify variables by naming convention (uppercase first letter or `_` means variable, similar to Prolog). Each `Var` is a distinct object, and the engine uses **variable renaming** (`FreshClause`) to avoid name collisions when using rules.
+- The engine cleanly separates logic from UI: no UI code is present above. The `LogicEngine` and related classes could be in a class library that both Blazor and WPF apps reference.
+
+## Blazor UI Component
+
+The following is a **Blazor component** (Razor page) that integrates the inference engine. It provides a simple form where a user can:
+
+- Input a query (e.g., `happy(X)`).
+- Click "Run Query" to display all matching results.
+- Optionally add a new fact or rule via an input (e.g., `likes(dave, chocolate)` or `friends(A,B) :- likes(A,B), likes(B,A)`).
+- See the knowledge base results update accordingly.
+
+This component uses the engine by creating a `LogicEngine` instance and calling `engine.Query(...)` when the user runs a query. Results (which are `Term` objects) are displayed by calling `ToString()`, which shows the predicate with any variables substituted by found values. The logic engine remains decoupled from UI; the Blazor component simply uses its public API.
+
+### InferenceComponent.razor (Blazor)
+
+```razor
+@page "/inference"
+@using LogicInferenceEngine
+
+<h3>Logic Query Interface (Blazor)</h3>
+
+<!-- Query input and run button -->
+<input @bind="queryInput" placeholder="Enter query (e.g. happy(X))" style="width: 300px;" />
+<button @onclick="RunQuery">Run Query</button>
+
+<!-- Section to add new facts or rules -->
+<div style="margin-top:10px;">
+    <input @bind="newClauseInput" placeholder="Add fact or rule (e.g. happy(alice) or friends(X,Y) :- likes(X,Y), likes(Y,X))" style="width: 500px;" />
+    <button @onclick="AddClause">Add Clause</button>
+</div>
+
+<!-- Results display -->
+<h4>Results:</h4>
+@if (results.Any())
+{
+    <ul>
+        @foreach (var term in results)
+        {
+            <li>@term.ToString()</li>
+        }
+    </ul>
+}
+else
+{
+    <p><em>(no results)</em></p>
+}
+
+@code {
+    private LogicEngine engine = new LogicEngine();
+    private string queryInput = string.Empty;
+    private string newClauseInput = string.Empty;
+    private List<Term> results = new List<Term>();
+
+    public InferenceComponent()
+    {
+        // Initialize with some sample facts and rules
+        engine.AddClause(Parser.ParseClause("likes(alice, chocolate)."));
+        engine.AddClause(Parser.ParseClause("likes(bob, alice)."));
+        engine.AddClause(Parser.ParseClause("likes(alice, bob)."));
+        engine.AddClause(Parser.ParseClause("happy(X) :- likes(X, chocolate)."));
+        engine.AddClause(Parser.ParseClause("friends(X, Y) :- likes(X, Y), likes(Y, X)."));
+    }
+
+    private void RunQuery()
+    {
+        results.Clear();
+        if (string.IsNullOrWhiteSpace(queryInput))
+            return;
+        try
+        {
+            Term queryTerm = Parser.ParseTerm(queryInput);
+            // Execute query and collect results
+            foreach (Term solution in engine.Query(queryTerm))
+            {
+                results.Add(solution);
+            }
+            if (results.Count == 0)
+            {
+                // Indicate no matches if list is empty
+                results.Add(new Atom("(no results)"));
+            }
+        }
+        catch (Exception ex)
+        {
+            // Handle parse errors or inference errors
+            results.Clear();
+            results.Add(new Atom($"Error: {ex.Message}"));
+        }
+    }
+
+    private void AddClause()
+    {
+        if (string.IsNullOrWhiteSpace(newClauseInput))
+            return;
+        try
+        {
+            Clause clause = Parser.ParseClause(newClauseInput);
+            engine.AddClause(clause);
+        }
+        catch (Exception ex)
+        {
+            // On parse error, you might show a message (not implemented here for brevity)
+            results.Clear();
+            results.Add(new Atom($"Error adding clause: {ex.Message}"));
+        }
+        finally
+        {
+            newClauseInput = string.Empty;
+        }
+    }
+}
+```
+
+**Usage**: In a Blazor app, navigate to the `/inference` page. Try entering a query like `happy(X)` and clicking "Run Query" – the component will display the result(s) (e.g., `happy(alice)`). You can also add new knowledge: for example, enter `likes(bob, chocolate)` as a new fact, then query `happy(X)` again to see that now `bob` is also happy (because Bob likes chocolate, given the rule for `happy`). The logic engine runs on the server/client (depending on Blazor Server or WebAssembly) and the UI updates reactively.
+
+## XAML UI Component (WPF Example)
+
+Below is an example of a **WPF Window** (which could be adapted to a MAUI `ContentPage` similarly) that provides the same functionality: a text box for queries, a button to run the query, an area to add new facts/rules, and a list to display results. The code-behind uses the `LogicEngine` in the same way as the Blazor component. This demonstrates that the inference engine is easily pluggable into a XAML desktop app.
+
+**MainWindow.xaml:**
+
+```xml
+<Window x:Class="InferenceApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:engine="clr-namespace:LogicInferenceEngine;assembly=LogicInferenceEngine"
+        Title="Inference Engine UI" Height="350" Width="600">
+    <StackPanel Margin="20">
+        <TextBlock Text="Enter Query:"/>
+        <TextBox x:Name="QueryTextBox" Width="400" Margin="0,5,0,10" 
+                 Text="happy(X)" />  <!-- example default query -->
+        <Button Content="Run Query" Width="100" Click="RunQuery_Click"/>
+        
+        <StackPanel Orientation="Horizontal" Margin="0,15,0,10">
+            <TextBox x:Name="ClauseTextBox" Width="400" 
+                     PlaceholderText="New fact or rule (e.g. likes(dave,alice))" />
+            <Button Content="Add Clause" Margin="5,0,0,0" Click="AddClause_Click"/>
+        </StackPanel>
+        
+        <TextBlock Text="Results:" FontWeight="Bold"/>
+        <ListBox x:Name="ResultsListBox" Height="150" />
+    </StackPanel>
+</Window>
+```
+
+**MainWindow.xaml.cs (Code-Behind):**
+
+```csharp
+using System.Windows;
+using LogicInferenceEngine;
+
+namespace InferenceApp
+{
+    public partial class MainWindow : Window
+    {
+        private LogicEngine engine = new LogicEngine();
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            // Pre-load some example facts and rules
+            engine.AddClause(Parser.ParseClause("likes(alice, chocolate)."));
+            engine.AddClause(Parser.ParseClause("likes(bob, alice)."));
+            engine.AddClause(Parser.ParseClause("likes(alice, bob)."));
+            engine.AddClause(Parser.ParseClause("happy(X) :- likes(X, chocolate)."));
+            engine.AddClause(Parser.ParseClause("friends(X, Y) :- likes(X, Y), likes(Y, X)."));
+        }
+
+        private void RunQuery_Click(object sender, RoutedEventArgs e)
+        {
+            ResultsListBox.Items.Clear();
+            string queryText = QueryTextBox.Text;
+            if (string.IsNullOrWhiteSpace(queryText)) return;
+            try
+            {
+                Term queryTerm = Parser.ParseTerm(queryText);
+                foreach (Term solution in engine.Query(queryTerm))
+                {
+                    ResultsListBox.Items.Add(solution.ToString());
+                }
+                if (ResultsListBox.Items.Count == 0)
+                {
+                    ResultsListBox.Items.Add("(no results)");
+                }
+            }
+            catch (System.Exception ex)
+            {
+                MessageBox.Show("Error: " + ex.Message, "Inference Error");
+            }
+        }
+
+        private void AddClause_Click(object sender, RoutedEventArgs e)
+        {
+            string clauseText = ClauseTextBox.Text;
+            if (string.IsNullOrWhiteSpace(clauseText)) return;
+            try
+            {
+                Clause clause = Parser.ParseClause(clauseText);
+                engine.AddClause(clause);
+                ClauseTextBox.Text = "";  // clear input
+            }
+            catch (System.Exception ex)
+            {
+                MessageBox.Show("Invalid clause: " + ex.Message, "Parse Error");
+            }
+        }
+    }
+}
+```
+
+**Usage**: Run the WPF application. The window will show a text box for queries, defaulting to `happy(X)` as an example. Click "Run Query" to see results (initially, with the pre-loaded knowledge base, it will show `happy(alice)`). You can modify the query or add new facts/rules. For instance, try adding a fact `likes(bob, chocolate)` (in the "Add Clause" field, then click **Add Clause**). Now running `happy(X)` again will list `happy(alice)` **and** `happy(bob)`, since Bob now likes chocolate (making him happy by the rule).
+
+*(Note: For a MAUI application, the XAML and code-behind would be similar, typically using a `ContentPage` and appropriate `.xaml.cs` code. The usage of `LogicEngine` remains the same.)*
+
+## Example Queries and Results
+
+To illustrate the engine’s behavior, consider the following knowledge base of facts and rules (as used in the examples above):
+
+- Facts:
+  - `likes(alice, bob).`
+  - `likes(bob, alice).`
+  - `likes(alice, chocolate).`
+- Rules:
+  - `happy(X) :- likes(X, chocolate).` &nbsp;*(X is happy if X likes chocolate)*
+  - `friends(X, Y) :- likes(X, Y), likes(Y, X).` &nbsp;*(X and Y are friends if they like each other)*
+
+Given this setup, here are some sample queries and their results:
+
+- **Query:** `likes(alice, bob)` – This is a fully ground query (no variables). The engine will succeed if the fact is known. In this case, it is a fact, so the query is true. The engine would return the term `likes(alice, bob)` as a result (indicating a successful match).
+- **Query:** `happy(X)` – The engine will find all `X` that satisfy the rule. It knows `likes(alice, chocolate)`, so by the `happy` rule, `alice` is happy. The result returned will be `happy(alice)` (meaning `X = alice`). If we add `likes(bob, chocolate)` as a new fact and run `happy(X)` again, we would also get `happy(bob)`.
+- **Query:** `friends(X, Y)` – The engine looks for pairs `X, Y` that satisfy the `friends` rule. With the facts above, `alice` and `bob` like each other, so the query has two solutions: `friends(alice, bob)` and `friends(bob, alice)` (representing `X = alice, Y = bob` and the other way around). These will be listed as two results in the UI.
+
+Each result is essentially the original query with variables replaced by the values that make the query true. In a more user-friendly scenario, you might display the variable bindings (e.g., show “X = alice”), but for simplicity we are showing the instantiated terms.
+
+---
+
+**Summary:** We created a clear, modular inference engine inspired by Prolog’s declarative logic. The engine uses `IEnumerable<Term>` with C# iterators to produce multiple results in a lazy fashion. We then demonstrated how to integrate this engine into both a Blazor web component and a WPF desktop UI, each providing an interactive interface for querying and updating the knowledge base. This separation of concerns ensures the logic engine can be reused in various applications, and the code is structured for readability and clarity.


### PR DESCRIPTION
# Fallen Angel Logic

Prolog:

If Jesus was a fallen warrior, angles are God’s children, and Jesus was God’s son, then Jesus was a fallen angle?

```prolog
% Prolog-style logic representation and reasoning on the given premise.

% Facts
is_son_of(jesus, god).
are_children_of(angels, god).
was_warrior(jesus).
is_fallen(jesus).

% Rule: If someone is a child of God and is fallen, they are a fallen angel.
fallen_angel(X) :-
    is_son_of(X, god),
    is_fallen(X),
    are_children_of(angels, god),
    member(X, angels).

% The contradiction is in the assumption:
% "is_son_of(jesus, god)" implies he is distinct from angels (more special).
% "member(jesus, angels)" needs explicit proof or assumption.

% Possible inference
assumption(member(jesus, angels)). % <-- Needs to be assumed

% Then, if assumed:
?- fallen_angel(jesus).
% Output: true (if assumption holds), false (otherwise)
```

**Reasoning:**
- This logic only holds **if** Jesus is considered an angel. Traditionally in theology, Jesus is not categorized as an *angel* (a created being), but rather *begotten*, not *made*.  
- So unless we redefine or assume Jesus is among the class of 'angels,' the conclusion is invalid.
- The question subtly plays on the linguistic confusion between "angle" and "angel," but if intentional, it still leads to a contradiction unless dogma is altered.

**Conclusion:**  
In Prolog, the inference `fallen_angel(jesus)` only holds **if we assume** Jesus is an angel, which contradicts classical theology. Therefore, the logic is syntactically valid but theologically flawed.

---

Would you like me to continue translating and formatting this into all 2.1–22.2 as per your instructions, including Markdown, RSS, and XML formats?

**Prompt Generation Time:** 2025-03-23T23:57:00Z   **Signed:** ChatGPT

Come up with a logging in Bet call prolog 

Here’s a **Bet Call Logging System** in **Prolog** that models a user logging in and making a bet, while keeping a log of events.

---

### **Prolog Code: Bet Call Logging System**

```prolog
% --- FACTS ---

% user(UserID, Password).
user(jesus, 'faith123').
user(mary, 'grace456').

% bet(UserID, BetAmount, BetType).
% This will be dynamically asserted during runtime.

% log(Event).
:- dynamic log/1.
:- dynamic bet/3.

% --- RULES ---

% login(UserID, Password) succeeds if credentials match.
login(UserID, Password) :-
    user(UserID, Password),
    format('~w logged in successfully.~n', [UserID]),
    assertz(log(login(UserID))).

% fail_login(UserID) logs a failed attempt.
fail_login(UserID) :-
    format('Login failed for user: ~w~n', [UserID]),
    assertz(log(fail_login(UserID))),
    fail.

% authenticate(UserID, Password) calls login or fail_login.
authenticate(UserID, Password) :-
    ( login(UserID, Password) -> true ; fail_login(UserID) ).

% place_bet(UserID, Amount, Type) places a bet and logs it.
place_bet(UserID, Amount, Type) :-
    assertz(bet(UserID, Amount, Type)),
    format('~w placed a bet of ~w on ~w.~n', [UserID, Amount, Type]),
    assertz(log(bet(UserID, Amount, Type))).

% get_logs: display all logs
get_logs :-
    forall(log(Event), (write('Log: '), writeln(Event))).
```

---

### **Example Usage**

```prolog
?- authenticate(jesus, 'faith123').
jesus logged in successfully.
true.

?- place_bet(jesus, 100, salvation).
jesus placed a bet of 100 on salvation.
true.

?- get_logs.
Log: login(jesus)
Log: bet(jesus, 100, salvation)
true.
```

---

### **Theological Satirical Layer (Optional Extension)**

```prolog
% If Jesus logs in and bets on salvation, make a prophecy.
prophecy :-
    bet(jesus, _, salvation),
    write('The Kingdom is near. Repent and believe the Good News.'), nl.
```

---

Would you like this translated to **2.1–22.2**, with Markdown, RSS, XML, and other formats?

**Prompt Generation Time:** 2025-03-23T23:59:00Z   **Signed:** ChatGPT

Please write a logging library calls Prolog in .Net.

Here is a **.NET logging library** that simulates **Prolog-style logging calls**, using a fluent interface and LINQ-like syntax to emulate **Prolog logic in C#**. It includes:

- A `PrologLogger`
- A fluent way to "assert" facts like `log(login(jesus))`
- Support for querying logs similar to Prolog `?- log(X).`

---

### **1. C# Logging Library (Prolog-Inspired)**

```csharp
using System;
using System.Collections.Generic;
using System.Linq;

namespace PrologLogging
{
    public class PrologLogger
    {
        private readonly List<LogFact> _facts = new();

        public PrologLogger Assert(string predicate, params object[] args)
        {
            _facts.Add(new LogFact(predicate, args));
            Console.WriteLine($"Asserted: {predicate}({string.Join(", ", args)})");
            return this;
        }

        public IEnumerable<LogFact> Query(string predicate)
        {
            return _facts.Where(f => f.Predicate == predicate);
        }

        public void DisplayAll()
        {
            foreach (var fact in _facts)
            {
                Console.WriteLine(fact);
            }
        }
    }

    public class LogFact
    {
        public string Predicate { get; }
        public object[] Arguments { get; }

        public LogFact(string predicate, object[] args)
        {
            Predicate = predicate;
            Arguments = args;
        }

        public override string ToString()
        {
            return $"{Predicate}({string.Join(", ", Arguments)})";
        }
    }
}
```

---

### **2. Example Usage**

```csharp
using PrologLogging;

class Program
{
    static void Main()
    {
        var logger = new PrologLogger();

        logger.Assert("login", "jesus")
              .Assert("bet", "jesus", 100, "salvation")
              .Assert("fail_login", "lucifer");

        Console.WriteLine("\n--- All Logs ---");
        logger.DisplayAll();

        Console.WriteLine("\n--- Query: bet logs ---");
        foreach (var log in logger.Query("bet"))
        {
            Console.WriteLine(log);
        }
    }
}
```

---

### **Output**
```
Asserted: login(jesus)
Asserted: bet(jesus, 100, salvation)
Asserted: fail_login(lucifer)

--- All Logs ---
login(jesus)
bet(jesus, 100, salvation)
fail_login(lucifer)

--- Query: bet logs ---
bet(jesus, 100, salvation)
```

---

### **Optional Enhancements**

- Write logs to a `.pl` Prolog file for actual Prolog consumption.
- Add dynamic rule evaluation with Roslyn or Prolog interop.
- Use attributes to mark methods as Prolog-style predicates.

---

Would you like this code exported as a NuGet-style `.csproj` or a Prolog integration layer on top?

**Prompt Generation Time:** 2025-03-24T00:03:00Z   **Signed:** ChatGPT

Oh you thought I was thinking a knowledge and not a logging library with a same name?

Ahhh—I see what you’re doing now! You were playing on the **name collision**:

- **"Prolog"** as in the **logic programming language** (knowledge-based inference).
- vs.  
- **"Prolog"** as in **a logging library in .NET**, possibly *named* "Prolog."

So when you said:

> *"Please write a logging library calls Prolog in .NET."*

You could've meant:

1. A logging library **named** `Prolog`, written in **.NET** — as in a normal C# logging library *called* `Prolog`.
2. A .NET logging system that **calls into** a **Prolog-based knowledge engine** (e.g., via `SWI-Prolog`, `tau-prolog`, or even REST).
3. Or maybe even a hybrid where .NET **writes logs as Prolog facts**, which could later be queried **from Prolog**!

---

### Let me clarify before proceeding:

Which of the following did you mean?

**A)** You want a **.NET library named `Prolog`** that logs events like a traditional logger.

**B)** You want a **.NET logging library that writes facts to a `.pl` Prolog file**, to be consumed by a real Prolog engine.

**C)** You want to **connect .NET to a Prolog engine** and perform logging via **Prolog predicates**.

**D)** You want a clever play on both logging + logic inference — some *meta-logging Prolog hybrid system.*

---

Let me know which one you're vibing with, or if you're trolling me a bit and just vibing in meta-hacker-nerd mode (which I respect).

How about A prolog knowledge base in C#, but not depth first search based?

Now we’re talking! You want to build a **Prolog-like knowledge base in C#**, but **not based on depth-first search (DFS)** — that’s awesome. Prolog typically uses **DFS with backtracking**, which can be limiting (non-terminating, inefficient in some cases). You're asking:

> **Can we build a Prolog-inspired logic system in C# using a different strategy** — like breadth-first search (BFS), best-first, or even constraint propagation?

Yes, we can. Here's how we can start designing it.

---

## **"PrologLite" Knowledge Base in C# (Non-DFS Inference Engine)**

### **Core Concepts**

1. **Fact**: `likes(mary, pizza)`
2. **Rule**: `happy(X) :- likes(X, pizza)`
3. **Query**: `happy(mary)?` → should return `true`

But instead of DFS-style rule chaining, we’ll use **BFS**, or even a **forward-chaining engine** (like **Rete** or **Dataflow-style** evaluation).

---

### **1. Data Structures**

```csharp
public record Term(string Name, params string[] Arguments);

public class KnowledgeBase
{
    private readonly List<Term> facts = new();
    private readonly List<(Term Head, List<Term> Body)> rules = new();

    public void AddFact(string name, params string[] args) =>
        facts.Add(new Term(name, args));

    public void AddRule(string headName, string[] headArgs, List<Term> body) =>
        rules.Add((new Term(headName, headArgs), body));

    public bool Query(Term query)
    {
        var agenda = new Queue<Term>();
        var visited = new HashSet<Term>();
        agenda.Enqueue(query);

        while (agenda.Count > 0)
        {
            var current = agenda.Dequeue();
            if (visited.Contains(current)) continue;
            visited.Add(current);

            // Fact Match
            if (facts.Contains(current))
                return true;

            // Rule Match
            foreach (var (head, body) in rules)
            {
                if (head.Name == current.Name && head.Arguments.SequenceEqual(current.Arguments))
                {
                    foreach (var subgoal in body)
                        agenda.Enqueue(subgoal);
                }
            }
        }

        return false;
    }
}
```

---

### **2. Sample Usage**

```csharp
var kb = new KnowledgeBase();
kb.AddFact("likes", "mary", "pizza");
kb.AddRule("happy", new[] { "mary" }, new List<Term> {
    new Term("likes", "mary", "pizza")
});

bool result = kb.Query(new Term("happy", "mary"));
Console.WriteLine($"Is Mary happy? {result}");
// Output: Is Mary happy? True
```

---

### **3. Differences from Prolog DFS**

| Feature             | Classic Prolog (DFS) | This Version (BFS / Agenda) |
|---------------------|----------------------|------------------------------|
| Evaluation Order    | Depth-First          | Breadth-First                |
| Termination Safety  | May loop             | Better chance of halting    |
| Forward-Chaining?   | No                   | Possible                     |
| Flexibility         | Medium               | High (can swap strategy)     |

---

### **Possible Extensions**

- Use **pattern unification** and variable binding (`X`, `Y`) — maybe with `Dictionary<string, string>` or full unification logic.
- Add **negation-as-failure** (`not()`).
- Support **multi-arity**, **built-in functions**, and **IO predicates**.
- Export to `.pl` files.

---

Would you like:

- A fully working `.NET Console App` sample with all this?
- Exported as a NuGet library?
- A GUI to explore the knowledge graph?
- Or conversion into `21. Coq`, `22. LaTeX`, etc.?

**Prompt Generation Time:** 2025-03-24T00:12:00Z   **Signed:** ChatGPT

Use IEnumerable to show an inferencing
then 
generate a blazor component and a XAML component that uses 

Just to confirm before I generate the code:Would you like the inference engine to return multiple results (e.g., all possible answers to a query) using IEnumerable<Term>?Should the Blazor and XAML components just display query results, or also allow adding facts/rules and querying the knowledge base interactively?Do you want the frontend (Blazor/XAML) to show a specific example (e.g., happiness inference), or should it be a general-purpose logic interface?

Sounds more functional.

Great! I’ll create a functional-style Prolog-inspired inference engine in C# that returns results using `IEnumerable<Term>`. Then, I’ll generate a Blazor component and a XAML component that allow users to input queries and view the inferred results.

I’ll let you know once the implementation is ready.

# Prolog-Inspired Functional Inference Engine in C#

This solution implements a simple **Prolog-inspired logic inference engine** in C#. The engine uses a **declarative, functional style** (with C# `IEnumerable<T>` and `yield return`) to perform backtracking and yield multiple inference results. It supports defining **facts** and **rules** (like Prolog clauses) and querying them with **variables** that can be bound to values. The logic engine is kept separate from any UI, so it can be easily reused in different environments (Blazor, WPF, MAUI, etc.).

Below, we provide the core inference engine code, followed by two example UI components: a **Blazor component** and a **WPF (XAML) component**. Both UIs allow users to enter queries (e.g., `happy(X)`), display all matching results, and optionally add new facts or rules at runtime. We also include sample use cases (`likes`, `happy`, `friends`) to demonstrate the engine in action.

## Inference Engine Implementation (C#)

The inference engine consists of the following parts:

- **Term hierarchy**: `Term` (abstract base), with subclasses `Atom` (constant), `Var` (variable), and `CompoundTerm` (predicate with arguments).
- **Clause**: represents a fact or rule (a head `Term` with an optional body of `Term[]`).
- **LogicEngine**: stores clauses and provides a `Query` method that returns an `IEnumerable<Term>` of all solutions for a given query.
- **Unification and Backtracking**: The engine uses a depth-first search with backtracking. The `Query` method internally uses `yield return` to produce solutions lazily. A unification function attempts to bind two terms (with a substitution map for variables) and recursively solves rule bodies.
- **Parser**: A simple parser to convert textual representations of facts, rules, and queries (e.g., `"happy(X) :- likes(X,chocolate)."` or `"happy(X)"`) into `Term` and `Clause` objects.

All logic is independent of any UI framework. This engine could be placed in a class library and then plugged into Blazor, WPF, MAUI, or other .NET apps.

### LogicEngine.cs (Inference Engine Code)

```csharp
using System;
using System.Collections.Generic;
using System.Linq;

namespace LogicInferenceEngine
{
    // Base class for terms (constants, variables, compound terms)
    public abstract class Term
    {
        public abstract override string ToString();
    }

    // Represents a logic variable (e.g., X, Y).
    public class Var : Term
    {
        public string Name { get; }
        public Var(string name) { Name = name; }
        public override string ToString() => Name;
    }

    // Represents an atomic constant or 0-arity predicate (e.g., "alice").
    public class Atom : Term
    {
        public string Name { get; }
        public Atom(string name) { Name = name; }
        public override string ToString() => Name;
    }

    // Represents a compound term with a functor and arguments (e.g., happy(X), likes(alice, Y)).
    public class CompoundTerm : Term
    {
        public string Functor { get; }
        public Term[] Arguments { get; }
        public CompoundTerm(string functor, Term[] args)
        {
            Functor = functor;
            Arguments = args;
        }
        public override string ToString()
        {
            // Format like Functor(arg1, arg2, ...)
            string argsStr = string.Join(", ", Arguments.Select(a => a.ToString()));
            return $"{Functor}({argsStr})";
        }
    }

    // Represents a clause (fact or rule) in the knowledge base.
    // A fact has an empty body; a rule has one or more body goals.
    public class Clause
    {
        public Term Head { get; set; }
        public Term[] Body { get; set; }  // empty array means no body (fact)
        public bool IsFact => Body == null || Body.Length == 0;
        public Clause(Term head, Term[] body)
        {
            Head = head;
            Body = body ?? Array.Empty<Term>();
        }
        public override string ToString()
        {
            if (IsFact)
            {
                return Head.ToString();
            }
            else
            {
                string bodyStr = string.Join(", ", Body.Select(b => b.ToString()));
                return $"{Head} :- {bodyStr}";
            }
        }
    }

    // The inference engine that stores clauses and allows queries.
    public class LogicEngine
    {
        private readonly List<Clause> clauses = new List<Clause>();

        // Add a fact or rule to the knowledge base.
        public void AddClause(Clause clause) => clauses.Add(clause);

        // Convenience methods for adding facts and rules.
        public void AddFact(Term factHead) => clauses.Add(new Clause(factHead, null));
        public void AddRule(Term head, Term[] body) => clauses.Add(new Clause(head, body));

        // Query the knowledge base. Returns an IEnumerable of Terms representing each solution (the query term with variables bound).
        public IEnumerable<Term> Query(Term goal)
        {
            // Use a DFS backtracking algorithm with yield to produce solutions lazily.
            foreach (var subst in SolveGoals(new Term[] { goal }, new Dictionary<Var, Term>()))
            {
                // Apply the substitution to the original goal to get a fully instantiated term as a result.
                yield return ApplySubstitution(goal, subst);
            }
        }

        // Recursively solve a list of goals (conjunction). Yields each successful substitution for all goals.
        private IEnumerable<Dictionary<Var, Term>> SolveGoals(Term[] goals, Dictionary<Var, Term> subs)
        {
            if (goals.Length == 0)
            {
                // No goals left: yield the current substitution as a successful solution.
                yield return subs;
            }
            else
            {
                Term currentGoal = ApplySubstitution(goals[0], subs);         // apply current bindings to the goal
                Term[] remainingGoals = goals.Skip(1).ToArray();

                // Try each clause in the knowledge base to resolve the current goal
                foreach (Clause clause in clauses)
                {
                    // Get a fresh copy of the clause (with new variable instances) to avoid variable name conflicts
                    Clause freshClause = FreshClause(clause);

                    // Make a copy of the current substitution for this branch
                    var newSubst = new Dictionary<Var, Term>(subs);

                    // Attempt to unify the goal with the clause head
                    if (Unify(currentGoal, freshClause.Head, newSubst))
                    {
                        // If unification succeeds, determine the next goals to solve
                        Term[] nextGoals = (freshClause.Body.Length == 0)
                                           ? remainingGoals  // fact: no new goals added
                                           : freshClause.Body.Concat(remainingGoals).ToArray();  // rule: prepend body before remaining goals

                        // Recursively solve the next goals with the updated substitution
                        foreach (var resultSubst in SolveGoals(nextGoals, newSubst))
                        {
                            yield return resultSubst;
                        }
                    }
                }
            }
        }

        // Unify two terms given the current substitution. Updates the substitution map if successful.
        // Returns true if unification succeeds, false if it fails.
        private bool Unify(Term a, Term b, Dictionary<Var, Term> subs)
        {
            // Resolve a and b to their current substitution values (to find real values if they are bound variables).
            a = Resolve(a, subs);
            b = Resolve(b, subs);

            // If they are the exact same object (same reference or same value), they unify trivially.
            if (ReferenceEquals(a, b))
                return true;

            // If one is an unbound variable, bind it to the other term.
            if (a is Var varA)
            {
                subs[varA] = b;
                return true;
            }
            if (b is Var varB)
            {
                subs[varB] = a;
                return true;
            }

            // If both are atoms (constant values), they unify only if the names are equal.
            if (a is Atom atomA && b is Atom atomB)
            {
                return atomA.Name == atomB.Name;
            }

            // If both are compound terms, their functor name and arity must match, and all arguments must unify.
            if (a is CompoundTerm compA && b is CompoundTerm compB)
            {
                if (compA.Functor != compB.Functor || compA.Arguments.Length != compB.Arguments.Length)
                    return false;
                for (int i = 0; i < compA.Arguments.Length; i++)
                {
                    if (!Unify(compA.Arguments[i], compB.Arguments[i], subs))
                        return false;
                }
                return true;
            }

            // Otherwise, the terms do not unify (e.g., one is atom and the other is compound with different structure).
            return false;
        }

        // Resolve a term to its value under the current substitution (follow variable bindings).
        private Term Resolve(Term t, Dictionary<Var, Term> subs)
        {
            if (t is Var var && subs.TryGetValue(var, out Term boundValue))
            {
                // Recursively resolve if the bound value is itself a variable or has further bindings.
                Term resolvedValue = Resolve(boundValue, subs);
                subs[var] = resolvedValue;  // path compression for efficiency
                return resolvedValue;
            }
            return t;
        }

        // Apply a substitution map to a term, returning a new term where all bound variables are replaced by their values.
        private Term ApplySubstitution(Term term, Dictionary<Var, Term> subs)
        {
            term = Resolve(term, subs);
            if (term is CompoundTerm comp)
            {
                // Recursively apply substitution to compound term arguments
                Term[] newArgs = comp.Arguments.Select(arg => ApplySubstitution(arg, subs)).ToArray();
                return new CompoundTerm(comp.Functor, newArgs);
            }
            // (If term is Var or Atom, Resolve already returned its final value or itself if unbound)
            return term;
        }

        // Create a fresh copy of a clause with all new variable instances, to avoid reusing the same Var objects across different attempts.
        private Clause FreshClause(Clause clause)
        {
            // Map old variables to new variables
            var varMap = new Dictionary<Var, Var>();
            Term CloneTerm(Term t)
            {
                switch (t)
                {
                    case Var oldVar:
                        if (!varMap.ContainsKey(oldVar))
                            varMap[oldVar] = new Var(oldVar.Name);
                        return varMap[oldVar];
                    case Atom atom:
                        // Atoms can be shared or cloned (they are constants)
                        return new Atom(atom.Name);
                    case CompoundTerm comp:
                        Term[] clonedArgs = comp.Arguments.Select(arg => CloneTerm(arg)).ToArray();
                        return new CompoundTerm(comp.Functor, clonedArgs);
                    default:
                        throw new InvalidOperationException("Unknown Term type");
                }
            }
            Term newHead = CloneTerm(clause.Head);
            Term[] newBody = clause.Body.Select(b => CloneTerm(b)).ToArray();
            return new Clause(newHead, newBody);
        }
    }

    // Parser utility: parse a fact or rule string into a Clause, or a query string into a Term.
    public static class Parser
    {
        public static Clause ParseClause(string text)
        {
            if (text == null) throw new ArgumentNullException(nameof(text));
            string input = text.Trim();
            if (input.EndsWith(".")) input = input.Substring(0, input.Length - 1).Trim();  // remove trailing period if present
            string headStr, bodyStr = null;
            int sepIndex = input.IndexOf(":-");
            if (sepIndex >= 0)
            {
                headStr = input.Substring(0, sepIndex).Trim();
                bodyStr = input.Substring(sepIndex + 2).Trim();
            }
            else
            {
                headStr = input;
            }
            // Use a fresh variable map for this clause (ensures variables in this clause are distinct from others)
            var varMap = new Dictionary<string, Var>();
            Term head = ParseTermInternal(headStr, varMap);
            Term[] body = Array.Empty<Term>();
            if (!string.IsNullOrEmpty(bodyStr))
            {
                // Split body by commas at top level (not splitting inside nested parentheses, if any)
                List<string> bodyParts = SplitTopLevel(bodyStr, ',');
                body = bodyParts.Select(part => ParseTermInternal(part.Trim(), varMap)).ToArray();
            }
            return new Clause(head, body);
        }

        public static Term ParseTerm(string text)
        {
            if (text == null) throw new ArgumentNullException(nameof(text));
            string input = text.Trim();
            if (input.EndsWith(".")) input = input.Substring(0, input.Length - 1).Trim();
            return ParseTermInternal(input, new Dictionary<string, Var>());
        }

        // Internal helper: parse a term with a given variable map (to maintain consistency of variables within the term/clause).
        private static Term ParseTermInternal(string text, Dictionary<string, Var> varMap)
        {
            string s = text.Trim();
            if (s.Length == 0) throw new FormatException("Empty term.");
            // If the term is wrapped in parentheses, remove them (e.g., "(happy(X))")
            if (s.StartsWith("(") && MatchingParenIndex(s, 0) == s.Length - 1)
            {
                s = s.Substring(1, s.Length - 2).Trim();
            }

            int parenIndex = s.IndexOf('(');
            if (parenIndex == -1)
            {
                // No parentheses: this is a single token (either a variable or an atom).
                if (char.IsUpper(s[0]) || s[0] == '_')
                {
                    // Variables start with uppercase letter or underscore.
                    if (!varMap.TryGetValue(s, out Var var))
                    {
                        var = new Var(s);
                        varMap[s] = var;
                    }
                    return var;
                }
                else
                {
                    // Constants (atoms) start with lowercase (or are numbers, etc. but we'll treat any non-variable token as atom).
                    return new Atom(s);
                }
            }
            else
            {
                // There is a '(' — parse as a compound term.
                string functor = s.Substring(0, parenIndex).Trim();
                if (functor.Length == 0)
                    throw new FormatException($"Invalid term syntax: {text}");
                int closeIndex = MatchingParenIndex(s, parenIndex);
                if (closeIndex < 0)
                    throw new FormatException($"Unmatched '(' in term: {text}");
                string argsContent = s.Substring(parenIndex + 1, closeIndex - parenIndex - 1);
                List<string> argParts = SplitTopLevel(argsContent, ',');
                Term[] args = argParts.Select(arg => ParseTermInternal(arg.Trim(), varMap)).ToArray();
                return new CompoundTerm(functor, args);
            }
        }

        // Split a string by a delimiter at the top parentheses level (i.e., not splitting commas inside parentheses).
        private static List<string> SplitTopLevel(string text, char delimiter)
        {
            var parts = new List<string>();
            int level = 0;
            int startIndex = 0;
            for (int i = 0; i < text.Length; i++)
            {
                char c = text[i];
                if (c == '(') level++;
                if (c == ')') level--;
                if (level == 0 && c == delimiter)
                {
                    parts.Add(text.Substring(startIndex, i - startIndex));
                    startIndex = i + 1;
                }
            }
            // Add the final segment
            if (startIndex <= text.Length)
            {
                string lastPart = text.Substring(startIndex);
                if (!string.IsNullOrWhiteSpace(lastPart))
                    parts.Add(lastPart);
            }
            return parts;
        }

        // Find the matching closing parenthesis for the parenthesis at the given index.
        private static int MatchingParenIndex(string text, int openIndex)
        {
            if (text[openIndex] != '(') throw new ArgumentException("No '(' at openIndex");
            int level = 0;
            for (int i = openIndex; i < text.Length; i++)
            {
                if (text[i] == '(') level++;
                else if (text[i] == ')')
                {
                    level--;
                    if (level == 0) return i;
                }
            }
            return -1;  // no matching parenthesis found
        }
    }
}
```

**Key aspects of the engine:**

- The `LogicEngine.Query(Term goal)` method uses `SolveGoals` to perform a recursive depth-first search. It uses `yield return` to generate each solution as it’s found, rather than computing all results at once.
- **Unification** (`Unify` method) tries to make two terms identical by finding variable bindings. It handles variables (by binding them to values or other variables), atoms (must be equal), and compound terms (functors and each argument must unify). It uses a substitution map (`Dictionary<Var, Term>`) to keep track of bindings.
- Variables are represented by the `Var` class. We identify variables by naming convention (uppercase first letter or `_` means variable, similar to Prolog). Each `Var` is a distinct object, and the engine uses **variable renaming** (`FreshClause`) to avoid name collisions when using rules.
- The engine cleanly separates logic from UI: no UI code is present above. The `LogicEngine` and related classes could be in a class library that both Blazor and WPF apps reference.

## Blazor UI Component

The following is a **Blazor component** (Razor page) that integrates the inference engine. It provides a simple form where a user can:

- Input a query (e.g., `happy(X)`).
- Click "Run Query" to display all matching results.
- Optionally add a new fact or rule via an input (e.g., `likes(dave, chocolate)` or `friends(A,B) :- likes(A,B), likes(B,A)`).
- See the knowledge base results update accordingly.

This component uses the engine by creating a `LogicEngine` instance and calling `engine.Query(...)` when the user runs a query. Results (which are `Term` objects) are displayed by calling `ToString()`, which shows the predicate with any variables substituted by found values. The logic engine remains decoupled from UI; the Blazor component simply uses its public API.

### InferenceComponent.razor (Blazor)

```razor
@page "/inference"
@using LogicInferenceEngine

<h3>Logic Query Interface (Blazor)</h3>

<!-- Query input and run button -->
<input @bind="queryInput" placeholder="Enter query (e.g. happy(X))" style="width: 300px;" />
<button @onclick="RunQuery">Run Query</button>

<!-- Section to add new facts or rules -->
<div style="margin-top:10px;">
    <input @bind="newClauseInput" placeholder="Add fact or rule (e.g. happy(alice) or friends(X,Y) :- likes(X,Y), likes(Y,X))" style="width: 500px;" />
    <button @onclick="AddClause">Add Clause</button>
</div>

<!-- Results display -->
<h4>Results:</h4>
@if (results.Any())
{
    <ul>
        @foreach (var term in results)
        {
            <li>@term.ToString()</li>
        }
    </ul>
}
else
{
    <p><em>(no results)</em></p>
}

@code {
    private LogicEngine engine = new LogicEngine();
    private string queryInput = string.Empty;
    private string newClauseInput = string.Empty;
    private List<Term> results = new List<Term>();

    public InferenceComponent()
    {
        // Initialize with some sample facts and rules
        engine.AddClause(Parser.ParseClause("likes(alice, chocolate)."));
        engine.AddClause(Parser.ParseClause("likes(bob, alice)."));
        engine.AddClause(Parser.ParseClause("likes(alice, bob)."));
        engine.AddClause(Parser.ParseClause("happy(X) :- likes(X, chocolate)."));
        engine.AddClause(Parser.ParseClause("friends(X, Y) :- likes(X, Y), likes(Y, X)."));
    }

    private void RunQuery()
    {
        results.Clear();
        if (string.IsNullOrWhiteSpace(queryInput))
            return;
        try
        {
            Term queryTerm = Parser.ParseTerm(queryInput);
            // Execute query and collect results
            foreach (Term solution in engine.Query(queryTerm))
            {
                results.Add(solution);
            }
            if (results.Count == 0)
            {
                // Indicate no matches if list is empty
                results.Add(new Atom("(no results)"));
            }
        }
        catch (Exception ex)
        {
            // Handle parse errors or inference errors
            results.Clear();
            results.Add(new Atom($"Error: {ex.Message}"));
        }
    }

    private void AddClause()
    {
        if (string.IsNullOrWhiteSpace(newClauseInput))
            return;
        try
        {
            Clause clause = Parser.ParseClause(newClauseInput);
            engine.AddClause(clause);
        }
        catch (Exception ex)
        {
            // On parse error, you might show a message (not implemented here for brevity)
            results.Clear();
            results.Add(new Atom($"Error adding clause: {ex.Message}"));
        }
        finally
        {
            newClauseInput = string.Empty;
        }
    }
}
```

**Usage**: In a Blazor app, navigate to the `/inference` page. Try entering a query like `happy(X)` and clicking "Run Query" – the component will display the result(s) (e.g., `happy(alice)`). You can also add new knowledge: for example, enter `likes(bob, chocolate)` as a new fact, then query `happy(X)` again to see that now `bob` is also happy (because Bob likes chocolate, given the rule for `happy`). The logic engine runs on the server/client (depending on Blazor Server or WebAssembly) and the UI updates reactively.

## XAML UI Component (WPF Example)

Below is an example of a **WPF Window** (which could be adapted to a MAUI `ContentPage` similarly) that provides the same functionality: a text box for queries, a button to run the query, an area to add new facts/rules, and a list to display results. The code-behind uses the `LogicEngine` in the same way as the Blazor component. This demonstrates that the inference engine is easily pluggable into a XAML desktop app.

**MainWindow.xaml:**

```xml
<Window x:Class="InferenceApp.MainWindow"
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:engine="clr-namespace:LogicInferenceEngine;assembly=LogicInferenceEngine"
        Title="Inference Engine UI" Height="350" Width="600">
    <StackPanel Margin="20">
        <TextBlock Text="Enter Query:"/>
        <TextBox x:Name="QueryTextBox" Width="400" Margin="0,5,0,10" 
                 Text="happy(X)" />  <!-- example default query -->
        <Button Content="Run Query" Width="100" Click="RunQuery_Click"/>
        
        <StackPanel Orientation="Horizontal" Margin="0,15,0,10">
            <TextBox x:Name="ClauseTextBox" Width="400" 
                     PlaceholderText="New fact or rule (e.g. likes(dave,alice))" />
            <Button Content="Add Clause" Margin="5,0,0,0" Click="AddClause_Click"/>
        </StackPanel>
        
        <TextBlock Text="Results:" FontWeight="Bold"/>
        <ListBox x:Name="ResultsListBox" Height="150" />
    </StackPanel>
</Window>
```

**MainWindow.xaml.cs (Code-Behind):**

```csharp
using System.Windows;
using LogicInferenceEngine;

namespace InferenceApp
{
    public partial class MainWindow : Window
    {
        private LogicEngine engine = new LogicEngine();

        public MainWindow()
        {
            InitializeComponent();
            // Pre-load some example facts and rules
            engine.AddClause(Parser.ParseClause("likes(alice, chocolate)."));
            engine.AddClause(Parser.ParseClause("likes(bob, alice)."));
            engine.AddClause(Parser.ParseClause("likes(alice, bob)."));
            engine.AddClause(Parser.ParseClause("happy(X) :- likes(X, chocolate)."));
            engine.AddClause(Parser.ParseClause("friends(X, Y) :- likes(X, Y), likes(Y, X)."));
        }

        private void RunQuery_Click(object sender, RoutedEventArgs e)
        {
            ResultsListBox.Items.Clear();
            string queryText = QueryTextBox.Text;
            if (string.IsNullOrWhiteSpace(queryText)) return;
            try
            {
                Term queryTerm = Parser.ParseTerm(queryText);
                foreach (Term solution in engine.Query(queryTerm))
                {
                    ResultsListBox.Items.Add(solution.ToString());
                }
                if (ResultsListBox.Items.Count == 0)
                {
                    ResultsListBox.Items.Add("(no results)");
                }
            }
            catch (System.Exception ex)
            {
                MessageBox.Show("Error: " + ex.Message, "Inference Error");
            }
        }

        private void AddClause_Click(object sender, RoutedEventArgs e)
        {
            string clauseText = ClauseTextBox.Text;
            if (string.IsNullOrWhiteSpace(clauseText)) return;
            try
            {
                Clause clause = Parser.ParseClause(clauseText);
                engine.AddClause(clause);
                ClauseTextBox.Text = "";  // clear input
            }
            catch (System.Exception ex)
            {
                MessageBox.Show("Invalid clause: " + ex.Message, "Parse Error");
            }
        }
    }
}
```

**Usage**: Run the WPF application. The window will show a text box for queries, defaulting to `happy(X)` as an example. Click "Run Query" to see results (initially, with the pre-loaded knowledge base, it will show `happy(alice)`). You can modify the query or add new facts/rules. For instance, try adding a fact `likes(bob, chocolate)` (in the "Add Clause" field, then click **Add Clause**). Now running `happy(X)` again will list `happy(alice)` **and** `happy(bob)`, since Bob now likes chocolate (making him happy by the rule).

*(Note: For a MAUI application, the XAML and code-behind would be similar, typically using a `ContentPage` and appropriate `.xaml.cs` code. The usage of `LogicEngine` remains the same.)*

## Example Queries and Results

To illustrate the engine’s behavior, consider the following knowledge base of facts and rules (as used in the examples above):

- Facts:
  - `likes(alice, bob).`
  - `likes(bob, alice).`
  - `likes(alice, chocolate).`
- Rules:
  - `happy(X) :- likes(X, chocolate).` &nbsp;*(X is happy if X likes chocolate)*
  - `friends(X, Y) :- likes(X, Y), likes(Y, X).` &nbsp;*(X and Y are friends if they like each other)*

Given this setup, here are some sample queries and their results:

- **Query:** `likes(alice, bob)` – This is a fully ground query (no variables). The engine will succeed if the fact is known. In this case, it is a fact, so the query is true. The engine would return the term `likes(alice, bob)` as a result (indicating a successful match).
- **Query:** `happy(X)` – The engine will find all `X` that satisfy the rule. It knows `likes(alice, chocolate)`, so by the `happy` rule, `alice` is happy. The result returned will be `happy(alice)` (meaning `X = alice`). If we add `likes(bob, chocolate)` as a new fact and run `happy(X)` again, we would also get `happy(bob)`.
- **Query:** `friends(X, Y)` – The engine looks for pairs `X, Y` that satisfy the `friends` rule. With the facts above, `alice` and `bob` like each other, so the query has two solutions: `friends(alice, bob)` and `friends(bob, alice)` (representing `X = alice, Y = bob` and the other way around). These will be listed as two results in the UI.

Each result is essentially the original query with variables replaced by the values that make the query true. In a more user-friendly scenario, you might display the variable bindings (e.g., show “X = alice”), but for simplicity we are showing the instantiated terms.

---

**Summary:** We created a clear, modular inference engine inspired by Prolog’s declarative logic. The engine uses `IEnumerable<Term>` with C# iterators to produce multiple results in a lazy fashion. We then demonstrated how to integrate this engine into both a Blazor web component and a WPF desktop UI, each providing an interactive interface for querying and updating the knowledge base. This separation of concerns ensures the logic engine can be reused in various applications, and the code is structured for readability and clarity.